### PR TITLE
fix: failing resynth test case 

### DIFF
--- a/src/topt_proto/clifford.py
+++ b/src/topt_proto/clifford.py
@@ -8,7 +8,6 @@ from pytket.passes import DecomposeBoxes
 from pytket.pauli import Pauli, QubitPauliTensor
 from pytket.tableau import UnitaryTableau
 from qiskit.synthesis import synth_cnot_count_full_pmh
-from pytket.circuit.display import view_browser as draw
 
 ### Background discussed here
 #  -> https://quantumcomputing.stackexchange.com/questions/39930/resynthesising-a-clifford-from-a-phase-polynomial-and-a-pauli-string

--- a/src/topt_proto/clifford.py
+++ b/src/topt_proto/clifford.py
@@ -8,6 +8,7 @@ from pytket.passes import DecomposeBoxes
 from pytket.pauli import Pauli, QubitPauliTensor
 from pytket.tableau import UnitaryTableau
 from qiskit.synthesis import synth_cnot_count_full_pmh
+from pytket.circuit.display import view_browser as draw
 
 ### Background discussed here
 #  -> https://quantumcomputing.stackexchange.com/questions/39930/resynthesising-a-clifford-from-a-phase-polynomial-and-a-pauli-string
@@ -32,11 +33,8 @@ def pauli_tensor_to_circuit(pauli_tensor: QubitPauliTensor) -> Circuit:
 def get_cnot_circuit(pbox: PhasePolyBox) -> Circuit:
     """Generate a CNOT circuit implementing the linear reversible circuit L."""
     # cheat by synthesising the CNOT circuit with qiskit and converting
-    qc = synth_cnot_count_full_pmh(
-        pbox.linear_transformation, section_size=2
-    )  # correct for endianness
-    qc2 = qc.reverse_bits()
-    tkc_cnot: Circuit = qiskit_to_tk(qc2)
+    qc = synth_cnot_count_full_pmh(pbox.linear_transformation, section_size=2)
+    tkc_cnot: Circuit = qiskit_to_tk(qc)
     return tkc_cnot
 
 
@@ -46,7 +44,7 @@ def get_pauli_conjugate(
 ) -> QubitPauliTensor:
     """Given a PhasePolyBox (U) and a QubitPauliTensor (P), returns P' = L P L†."""
 
-    l_cnot_circuit: Circuit = get_cnot_circuit(pbox=pbox)
+    l_cnot_circuit: Circuit = get_cnot_circuit(pbox=pbox).dagger()
 
     # Get L as a Tableau
     l_tableau = UnitaryTableau(l_cnot_circuit)

--- a/tests/qasm/cnot_t_4.qasm
+++ b/tests/qasm/cnot_t_4.qasm
@@ -1,0 +1,13 @@
+OPENQASM 2.0;
+include "qelib1.inc";
+
+qreg q[3];
+cx q[2],q[0];
+rz(0.25*pi) q[0];
+cx q[1],q[0];
+cx q[2],q[0];
+rz(0.25*pi) q[0];
+cx q[1],q[0];
+cx q[0],q[1];
+cx q[1],q[0];
+rz(0.25*pi) q[1];


### PR DESCRIPTION
All tests for the clifford resynthesis now pass.

closes #8 

The failing test case was this circuit

```
OPENQASM 2.0;
include "qelib1.inc";

qreg q[3];
cx q[2],q[0];
rz(0.25*pi) q[0];
cx q[1],q[0];
cx q[2],q[0];
rz(0.25*pi) q[0];
cx q[1],q[0];
cx q[0],q[1];
cx q[1],q[0];
rz(0.25*pi) q[1];
```



Seems the linear revsersible circuit $L$ generated by get CNOT circuit was incorrect. It was generating 
```python
Circuit(3).CX(2, 1).CX(1, 2)
```
which maps $I X I \mapsto XX I$

The correct $L$ circuit was
```python
Circuit(3).CX(1, 0).CX(0, 1)
```

 which maps $IXI \mapsto X II$ instead.


Turns out that removing the reversal of bits before `qiskit_to_tk` and inverting the circuit before conjugating with $P$ did the trick. Feels rather like fudging unfortunately.

I suspect the underlying cause is that conjugation in `UnitaryTableau` follows $L^\dagger P L$ rather than $LP L^\dagger$. 