### PR TITLE
feat: add a `REPLACE_CONDITIONALS` pass

### DIFF
--- a/src/topt_proto/__init__.py
+++ b/src/topt_proto/__init__.py
@@ -10,7 +10,7 @@ from .gadgetisation import (
     gadgetise_hadamards,
     get_n_internal_hadamards,
     get_clifford_boundary,
-    REPLACE_MEASURES,
+    REPLACE_CONDITIONALS,
 )
 from .utils import (
     check_phasepolybox,
@@ -39,5 +39,5 @@ __all__ = [
     "reverse_circuit",
     "tensor_from_x_index",
     "REPLACE_T_WITH_RZ",
-    "REPLACE_MEASURES",
+    "REPLACE_CONDITIONALS",
 ]

--- a/src/topt_proto/__init__.py
+++ b/src/topt_proto/__init__.py
@@ -10,6 +10,7 @@ from .gadgetisation import (
     gadgetise_hadamards,
     get_n_internal_hadamards,
     get_clifford_boundary,
+    REPLACE_MEASURES,
 )
 from .utils import (
     check_phasepolybox,
@@ -19,7 +20,6 @@ from .utils import (
     reverse_circuit,
     tensor_from_x_index,
     REPLACE_T_WITH_RZ,
-    REPLACE_MEASURES,
 )
 
 __all__ = [

--- a/src/topt_proto/__init__.py
+++ b/src/topt_proto/__init__.py
@@ -19,6 +19,7 @@ from .utils import (
     reverse_circuit,
     tensor_from_x_index,
     REPLACE_T_WITH_RZ,
+    REPLACE_MEASURES,
 )
 
 __all__ = [
@@ -38,4 +39,5 @@ __all__ = [
     "reverse_circuit",
     "tensor_from_x_index",
     "REPLACE_T_WITH_RZ",
+    "REPLACE_MEASURES",
 ]

--- a/src/topt_proto/gadgetisation.py
+++ b/src/topt_proto/gadgetisation.py
@@ -114,7 +114,7 @@ def gadgetise_hadamards(circ: Circuit) -> Circuit:
 REPLACE_HADAMARDS = CustomPass(gadgetise_hadamards)
 
 
-def replace_measures(circ: Circuit) -> Circuit:
+def replace_conditionals(circ: Circuit) -> Circuit:
     circ_prime = initialise_registers(circ)
 
     for cmd in circ:
@@ -143,4 +143,4 @@ def replace_measures(circ: Circuit) -> Circuit:
     return circ_prime
 
 
-REPLACE_MEASURES = CustomPass(replace_measures)
+REPLACE_CONDITIONALS = CustomPass(replace_conditionals)

--- a/src/topt_proto/gadgetisation.py
+++ b/src/topt_proto/gadgetisation.py
@@ -126,7 +126,7 @@ def replace_measures(circ: Circuit) -> Circuit:
             case OpType.Conditional:
                 if cmd.op.width != 1:
                     raise NotImplementedError(
-                        "Replacement not implemented for more than one control bit."
+                        f"Replacement not implemented for more than one condition bit ({cmd.op} has {cmd.op.width})."
                     )
                 if cmd.op.op.type == OpType.X:
                     target_qubit = cmd.qubits[0]

--- a/src/topt_proto/gadgetisation.py
+++ b/src/topt_proto/gadgetisation.py
@@ -128,13 +128,12 @@ def replace_measures(circ: Circuit) -> Circuit:
                     raise NotImplementedError(
                         "Replacement not implemented for more than one control bit."
                     )
-                base_op = cmd.op.op
-                if base_op.type == OpType.X:
+                if cmd.op.op.type == OpType.X:
                     target_qubit = cmd.qubits[0]
                     circ_prime.CX(control_qubit, target_qubit)
                 else:
                     raise NotImplementedError(
-                        f"Replacement for {base_op.type} not implemented."
+                        f"Replacement for {cmd.op.op.type} not implemented."
                     )
             case OpType.Barrier:
                 circ_prime.add_barrier(cmd.qubits)

--- a/src/topt_proto/gadgetisation.py
+++ b/src/topt_proto/gadgetisation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pytket._tket.circuit import CircBox, Circuit, Command, OpType
 from pytket.passes import CustomPass
 from pytket.predicates import GateSetPredicate
+from topt_proto.utils import initialise_registers
 
 FSWAP_CIRC = Circuit(2, name="FSWAP").CZ(0, 1).SWAP(0, 1)
 

--- a/src/topt_proto/utils.py
+++ b/src/topt_proto/utils.py
@@ -91,38 +91,3 @@ def convert_t_to_rz(circ: Circuit) -> Circuit:
 
 
 REPLACE_T_WITH_RZ = CustomPass(convert_t_to_rz)
-
-
-def replace_measures(circ: Circuit) -> Circuit:
-    circ_prime = initialise_registers(circ)
-
-    for cmd in circ:
-        match cmd.op.type:
-            case OpType.Measure:
-                hold_qubit = cmd.qubits[0]
-                continue
-
-            case OpType.Conditional:
-                if cmd.op.width != 1:
-                    raise NotImplementedError(
-                        "Replacement not implemented for more than one control bit."
-                    )
-                base_op = cmd.op.op
-                if base_op.type == OpType.X:
-                    circ_prime.CX(hold_qubit, cmd.qubits[0])
-                elif base_op.type == OpType.U1:
-                    circ_prime.CU1(cmd.op.params, hold_qubit, cmd.qubits[0])
-                else:
-                    raise NotImplementedError(
-                        f"Replacement for {base_op.type} not implemented."
-                    )
-            case OpType.Barrier:
-                circ_prime.add_barrier(cmd.qubits)
-            case _:
-
-                circ_prime.add_gate(cmd.op, cmd.args)
-
-    return circ_prime
-
-
-REPLACE_MEASURES = CustomPass(replace_measures)

--- a/src/topt_proto/utils.py
+++ b/src/topt_proto/utils.py
@@ -91,3 +91,38 @@ def convert_t_to_rz(circ: Circuit) -> Circuit:
 
 
 REPLACE_T_WITH_RZ = CustomPass(convert_t_to_rz)
+
+
+def replace_measures(circ: Circuit) -> Circuit:
+    circ_prime = initialise_registers(circ)
+
+    for cmd in circ:
+        match cmd.op.type:
+            case OpType.Measure:
+                hold_qubit = cmd.qubits[0]
+                continue
+
+            case OpType.Conditional:
+                if cmd.op.width != 1:
+                    raise NotImplementedError(
+                        "Replacement not implemented for more than one control bit."
+                    )
+                base_op = cmd.op.op
+                if base_op.type == OpType.X:
+                    circ_prime.CX(hold_qubit, cmd.qubits[0])
+                elif base_op.type == OpType.U1:
+                    circ_prime.CU1(cmd.op.params, hold_qubit, cmd.qubits[0])
+                else:
+                    raise NotImplementedError(
+                        f"Replacement for {base_op.type} not implemented."
+                    )
+            case OpType.Barrier:
+                circ_prime.add_barrier(cmd.qubits)
+            case _:
+
+                circ_prime.add_gate(cmd.op, cmd.args)
+
+    return circ_prime
+
+
+REPLACE_MEASURES = CustomPass(replace_measures)

--- a/tests/test_gadgetisation.py
+++ b/tests/test_gadgetisation.py
@@ -1,11 +1,12 @@
 import pytest
 
-from pytket._tket.circuit import Circuit
+from pytket.circuit import Circuit, OpType
 from pytket.passes import DecomposeBoxes, ComposePhasePolyBoxes
 
 from topt_proto.gadgetisation import (
     REPLACE_HADAMARDS,
     get_n_internal_hadamards,
+    REPLACE_MEASURES,
 )
 from topt_proto.utils import get_n_conditional_paulis
 
@@ -51,8 +52,16 @@ def test_h_gadgetisation(circ: Circuit) -> None:
     ComposePhasePolyBoxes().apply(circ)
     n_internal_h_gates = get_n_internal_hadamards(circ)
     REPLACE_HADAMARDS.apply(circ)
-    assert get_n_conditional_paulis(circ) == n_internal_h_gates
+    n_conditionals = get_n_conditional_paulis(circ)
+    assert n_conditionals == n_internal_h_gates
     assert circ.n_qubits == n_qubits_without_ancillas + n_internal_h_gates
+    REPLACE_MEASURES.apply(circ)
+    assert circ.n_gates_of_type(OpType.CX) == n_conditionals
+    assert (
+        circ.n_gates_of_type(OpType.Measure)
+        == circ.n_gates_of_type(OpType.Conditional)
+        == 0
+    )
 
 
 # QFT circuit builder function, used in testing.
@@ -80,5 +89,13 @@ def test_gadgetisation_qft(n_qubits: int) -> None:
     n_internal_h_gates = get_n_internal_hadamards(qft_circ)
     assert n_internal_h_gates == n_qubits - 1
     REPLACE_HADAMARDS.apply(qft_circ)
-    assert get_n_conditional_paulis(qft_circ) == n_internal_h_gates
+    n_conditionals = get_n_conditional_paulis(qft_circ)
+    assert n_conditionals == n_internal_h_gates
     assert qft_circ.n_qubits == n_qubits + n_internal_h_gates
+    REPLACE_MEASURES.apply(qft_circ)
+    assert qft_circ.n_gates_of_type(OpType.CX) == n_conditionals
+    assert (
+        qft_circ.n_gates_of_type(OpType.Measure)
+        == qft_circ.n_gates_of_type(OpType.Conditional)
+        == 0
+    )

--- a/tests/test_gadgetisation.py
+++ b/tests/test_gadgetisation.py
@@ -6,7 +6,7 @@ from pytket.passes import DecomposeBoxes, ComposePhasePolyBoxes
 from topt_proto.gadgetisation import (
     REPLACE_HADAMARDS,
     get_n_internal_hadamards,
-    REPLACE_MEASURES,
+    REPLACE_CONDITIONALS,
 )
 from topt_proto.utils import get_n_conditional_paulis
 
@@ -55,7 +55,7 @@ def test_h_gadgetisation(circ: Circuit) -> None:
     n_conditionals = get_n_conditional_paulis(circ)
     assert n_conditionals == n_internal_h_gates
     assert circ.n_qubits == n_qubits_without_ancillas + n_internal_h_gates
-    REPLACE_MEASURES.apply(circ)
+    REPLACE_CONDITIONALS.apply(circ)
     assert circ.n_gates_of_type(OpType.CX) == n_conditionals
     assert (
         circ.n_gates_of_type(OpType.Measure)
@@ -92,7 +92,7 @@ def test_gadgetisation_qft(n_qubits: int) -> None:
     n_conditionals = get_n_conditional_paulis(qft_circ)
     assert n_conditionals == n_internal_h_gates
     assert qft_circ.n_qubits == n_qubits + n_internal_h_gates
-    REPLACE_MEASURES.apply(qft_circ)
+    REPLACE_CONDITIONALS.apply(qft_circ)
     assert qft_circ.n_gates_of_type(OpType.CX) == n_conditionals
     assert (
         qft_circ.n_gates_of_type(OpType.Measure)


### PR DESCRIPTION
closes #17 

Adds a pass to replace measures and conditional-X gates with CX gates (more gates can be added if needed). Added it to the gadgetisation file for ease of testing. 

Its a bit of a hack and I find the code for this kindof ugly but I need it for something so I'll add it here for now. 