### PR TITLE
fix: remove blank wires in `REPLACE_CONDITIONALS` pass

### DIFF
--- a/src/topt_proto/gadgetisation.py
+++ b/src/topt_proto/gadgetisation.py
@@ -140,6 +140,8 @@ def replace_conditionals(circ: Circuit) -> Circuit:
             case _:
                 circ_prime.add_gate(cmd.op, cmd.args)
 
+    circ_prime.remove_blank_wires()
+
     return circ_prime
 
 

--- a/tests/test_gadgetisation.py
+++ b/tests/test_gadgetisation.py
@@ -62,6 +62,7 @@ def test_h_gadgetisation(circ: Circuit) -> None:
         == circ.n_gates_of_type(OpType.Conditional)
         == 0
     )
+    assert circ.n_bits == 0
 
 
 # QFT circuit builder function, used in testing.
@@ -99,3 +100,4 @@ def test_gadgetisation_qft(n_qubits: int) -> None:
         == qft_circ.n_gates_of_type(OpType.Conditional)
         == 0
     )
+    assert qft_circ.n_bits == 0


### PR DESCRIPTION
Minor change cleaning up the output circuit after `REPLACE_CONDITIONALS` is applied.